### PR TITLE
allow use of recent versions of cppyy

### DIFF
--- a/cpython/setup.py
+++ b/cpython/setup.py
@@ -37,6 +37,6 @@ setup(
         ('topologic/include/Utilities', [f for f in copy_dir("./include/Utilities")])
     ],
     install_requires=[
-        'cppyy==1.3.0'
+        'cppyy>=1.3.0'
     ]
 )


### PR DESCRIPTION
This fix removes the requirement for a particular version of cppyy (also testing CLA)