### PR TITLE
Use Topologic Core separated as dependency `topologic-core`

### DIFF
--- a/Aperture.py
+++ b/Aperture.py
@@ -15,7 +15,7 @@
 # this program. If not, see <https://www.gnu.org/licenses/>.
 
 import topologicpy
-import topologic
+import topologic_core as topologic
 
 class Aperture(topologic.Aperture):
     @staticmethod

--- a/Cell.py
+++ b/Cell.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License along with
 # this program. If not, see <https://www.gnu.org/licenses/>.
 
-import topologic
+import topologic_core as topologic
 from topologicpy.Wire import Wire
 from topologicpy.Topology import Topology
 import math

--- a/CellComplex.py
+++ b/CellComplex.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License along with
 # this program. If not, see <https://www.gnu.org/licenses/>.
 
-import topologic
+import topologic_core as topologic
 import math
 import os
 from topologicpy.Topology import Topology

--- a/Cluster.py
+++ b/Cluster.py
@@ -15,7 +15,7 @@
 # this program. If not, see <https://www.gnu.org/licenses/>.
 
 from topologicpy.Topology import Topology
-import topologic
+import topologic_core as topologic
 import os
 import warnings
 

--- a/Context.py
+++ b/Context.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License along with
 # this program. If not, see <https://www.gnu.org/licenses/>.
 
-import topologic
+import topologic_core as topologic
 
 class Context:
     @staticmethod

--- a/Dictionary.py
+++ b/Dictionary.py
@@ -14,8 +14,8 @@
 # You should have received a copy of the GNU Affero General Public License along with
 # this program. If not, see <https://www.gnu.org/licenses/>.
 
-import topologic
-from topologic import IntAttribute, DoubleAttribute, StringAttribute, ListAttribute
+import topologic_core as topologic
+from topologic_core import IntAttribute, DoubleAttribute, StringAttribute, ListAttribute
 
 class Dictionary(topologic.Dictionary):
     '''

--- a/Edge.py
+++ b/Edge.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License along with
 # this program. If not, see <https://www.gnu.org/licenses/>.
 
-import topologic
+import topologic_core as topologic
 from topologicpy.Vertex import Vertex
 from topologicpy.Vector import Vector
 from topologicpy.Topology import Topology
@@ -803,7 +803,7 @@ class Edge(Topology):
         """
         import numpy as np
         from numpy.linalg import norm
-        import topologic
+        import topologic_core as topologic
         from topologicpy.Vertex import Vertex
         from topologicpy.Topology import Topology
 

--- a/EnergyModel.py
+++ b/EnergyModel.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License along with
 # this program. If not, see <https://www.gnu.org/licenses/>.
 
-import topologic
+import topologic_core as topologic
 import shutil
 import math
 from collections import OrderedDict

--- a/Face.py
+++ b/Face.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License along with
 # this program. If not, see <https://www.gnu.org/licenses/>.
 
-import topologic
+import topologic_core as topologic
 from topologicpy.Vector import Vector
 from topologicpy.Wire import Wire
 from topologicpy.Topology import Topology
@@ -1872,7 +1872,7 @@ class Face(Topology):
                     warnings.warn("Face.Triangulate - Error: Could not import gmsh. Please try to install gmsh manually. Returning None.")
                     return None
 
-            import topologic
+            import topologic_core as topologic
             from topologicpy.Vertex import Vertex
             from topologicpy.Wire import Wire
             from topologicpy.Face import Face

--- a/Graph.py
+++ b/Graph.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License along with
 # this program. If not, see <https://www.gnu.org/licenses/>.
 
-import topologic
+import topologic_core as topologic
 from topologicpy.Dictionary import Dictionary
 from topologicpy.Topology import Topology
 from topologicpy.Aperture import Aperture
@@ -518,7 +518,7 @@ class Graph:
 
         """
         from topologicpy.Vertex import Vertex
-        import topologic
+        import topologic_core as topologic
 
         if not isinstance(graph, topologic.Graph):
             print("Graph.LocalClusteringCoefficient - Error: The input graph parameter is not a valid graph. Returning None.")
@@ -5613,7 +5613,7 @@ class Graph:
             The computed global clustering coefficient.
 
         """
-        import topologic
+        import topologic_core as topologic
 
         def global_clustering_coefficient(adjacency_matrix):
             total_triangles = 0
@@ -6078,7 +6078,7 @@ class Graph:
 
         """
         from topologicpy.Vertex import Vertex
-        import topologic
+        import topologic_core as topologic
 
         def local_clustering_coefficient(adjacency_matrix, node):
             """
@@ -6527,7 +6527,7 @@ class Graph:
         from topologicpy.Graph import Graph
         from topologicpy.Cluster import Cluster
         from topologicpy.Topology import Topology
-        import topologic
+        import topologic_core as topologic
         from tqdm.auto import tqdm
 
         if not isinstance(face, topologic.Face):

--- a/Grid.py
+++ b/Grid.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License along with
 # this program. If not, see <https://www.gnu.org/licenses/>.
 
-import topologic
+import topologic_core as topologic
 
 class Grid(topologic.Cluster):
     @staticmethod

--- a/Honeybee.py
+++ b/Honeybee.py
@@ -109,7 +109,7 @@ except:
         warnings.warn("Honeybee - Error: Could not import ladybug-geometry")
 
 import json
-import topologic
+import topologic_core as topologic
 
 class Honeybee:
     @staticmethod

--- a/Plotly.py
+++ b/Plotly.py
@@ -15,7 +15,7 @@
 # this program. If not, see <https://www.gnu.org/licenses/>.
 
 import topologicpy
-import topologic
+import topologic_core as topologic
 
 from topologicpy.Wire import Wire
 from topologicpy.Face import Face

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ topologicpy depends on the following python libraries which will be installed au
 * [ipfshttpclient](https://pypi.org/project/ipfshttpclient/) >= 0.7.0
 * [web3](https://web3py.readthedocs.io/en/stable/) >=5.30.0
 * [openstudio](https://openstudio.net/) >= 3.4.0
+* [topologic_core](https://pypi.org/project/topologic_core/) >= 6.0.6
 * [lbt-ladybug](https://pypi.org/project/lbt-ladybug/) >= 0.25.161
 * [lbt-honeybee](https://pypi.org/project/lbt-honeybee/) >= 0.6.12
 * [honeybee-energy](https://pypi.org/project/honeybee-energy/) >= 1.91.49

--- a/Shell.py
+++ b/Shell.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License along with
 # this program. If not, see <https://www.gnu.org/licenses/>.
 
-import topologic
+import topologic_core as topologic
 from topologicpy.Topology import Topology
 import math
 import os
@@ -1270,7 +1270,7 @@ class Shell(Topology):
         from topologicpy.Cluster import Cluster
         from topologicpy.Topology import Topology
         from topologicpy.Dictionary import Dictionary
-        import topologic
+        import topologic_core as topologic
         import math
 
         def nearest_vertex_2d(v, vertices, tolerance=0.001):
@@ -1436,7 +1436,7 @@ class Shell(Topology):
         from topologicpy.Wire import Wire
         from topologicpy.Face import Face
         from topologicpy.Topology import Topology
-        import topologic
+        import topologic_core as topologic
         import math
 
         if not isinstance(face, topologic.Face):

--- a/Topology.py
+++ b/Topology.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License along with
 # this program. If not, see <https://www.gnu.org/licenses/>.
 
-import topologic
+import topologic_core as topologic
 from topologicpy.Aperture import Aperture
 from topologicpy.Dictionary import Dictionary
 import warnings
@@ -5074,7 +5074,7 @@ class Topology():
             The input topology with the identified faces removed.
 
         """
-        from topologic.Vertex import Vertex
+        from topologic_core.Vertex import Vertex
         from topologicpy.Face import Face
 
         if not isinstance(topology, topologic.Topology):

--- a/Vector.py
+++ b/Vector.py
@@ -267,7 +267,7 @@ class Vector(list):
         """
 
         from topologicpy.Vertex import Vertex
-        import topologic
+        import topologic_core as topologic
         if not isinstance(vertices, list):
             return None
         if not isinstance(normalize, bool):

--- a/Vertex.py
+++ b/Vertex.py
@@ -15,7 +15,7 @@
 # this program. If not, see <https://www.gnu.org/licenses/>.
 
 import topologicpy
-import topologic
+import topologic_core as topologic
 from topologicpy.Face import Face
 from topologicpy.Topology import Topology
 import collections

--- a/Wire.py
+++ b/Wire.py
@@ -16,7 +16,7 @@
 
 from binascii import a2b_base64
 from re import A
-import topologic
+import topologic_core as topologic
 from topologicpy.Topology import Topology
 import math
 import itertools
@@ -2282,7 +2282,7 @@ class Wire(Topology):
         from topologicpy.Topology import Topology
         from topologicpy.Dictionary import Dictionary
         from topologicpy.Helper import Helper
-        import topologic
+        import topologic_core as topologic
         import math
 
         def subtrees_to_edges(subtrees, polygon, slope):

--- a/__init__.py
+++ b/__init__.py
@@ -21,18 +21,6 @@ from sys import platform
 __version__ = '0.5.9'
 __version_info__ = tuple([ int(num) for num in __version__.split('.')])
 
-if platform == 'win32':
-    os_name = 'windows'
-elif platform == "darwin":
-    os_name = 'macos'
-else:
-    os_name = 'linux'
 
-sitePackagesFolderName = os.path.join(os.path.dirname(os.path.realpath(__file__)), "bin", os_name)
-test1 = os.path.dirname(os.path.realpath(__file__))
-topologicFolderName = [filename for filename in os.listdir(sitePackagesFolderName) if filename.startswith("topologic")][0]
-topologicPath = os.path.join(sitePackagesFolderName, topologicFolderName)
-sys.path.append(topologicPath.replace(".libs",""))
-
-import topologic
+import topologic_core as topologic
 

--- a/bin/linux/topologic/__init__.py
+++ b/bin/linux/topologic/__init__.py
@@ -1,2 +1,0 @@
-# re-export the extension module
-from .topologic import *

--- a/bin/macos/topologic/__init__.py
+++ b/bin/macos/topologic/__init__.py
@@ -1,2 +1,0 @@
-# re-export the extension module
-from .topologic import *

--- a/bin/windows/topologic/__init__.py
+++ b/bin/windows/topologic/__init__.py
@@ -1,2 +1,0 @@
-# re-export the extension module
-from .topologic import *

--- a/tests/01Vertex.py
+++ b/tests/01Vertex.py
@@ -5,7 +5,7 @@ import sys
 sys.path.append("C:/Users/wassimj/Documents/GitHub")
 
 import topologicpy
-import topologic
+import topologic_core as topologic
 from topologicpy.Vertex import Vertex
 from topologicpy.Edge import Edge
 from topologicpy.Cluster import Cluster

--- a/tests/02Edge.py
+++ b/tests/02Edge.py
@@ -5,7 +5,7 @@ sys.path.append("C:/Users/wassimj/Documents/GitHub")
 
 #Importing libraries
 import topologicpy
-import topologic
+import topologic_core as topologic
 from topologicpy.Vertex import Vertex
 from topologicpy.Edge import Edge
 from topologicpy.Cluster import Cluster

--- a/tests/03Wire.py
+++ b/tests/03Wire.py
@@ -5,7 +5,7 @@ import sys
 sys.path.append("C:/Users/wassimj/Documents/GitHub")
 
 import topologicpy 
-import topologic
+import topologic_core as topologic
 from topologicpy.Topology import Topology
 from topologicpy.Vertex import Vertex
 from topologicpy.Edge import Edge

--- a/tests/04Face.py
+++ b/tests/04Face.py
@@ -5,7 +5,7 @@ import sys
 sys.path.append("C:/Users/wassimj/Documents/GitHub")
 
 import topologicpy 
-import topologic
+import topologic_core as topologic
 from topologicpy.Topology import Topology
 from topologicpy.Vertex import Vertex
 from topologicpy.Edge import Edge

--- a/tests/05Shell.py
+++ b/tests/05Shell.py
@@ -5,7 +5,7 @@ import sys
 sys.path.append("C:/Users/wassimj/Documents/GitHub")
 
 import topologicpy
-import topologic
+import topologic_core as topologic
 from topologicpy.Vertex import Vertex
 from topologicpy.Edge import Edge
 from topologicpy.Cluster import Cluster

--- a/tests/06Cell.py
+++ b/tests/06Cell.py
@@ -5,7 +5,7 @@ import sys
 sys.path.append("C:/Users/wassimj/Documents/GitHub")
 
 import topologicpy
-import topologic
+import topologic_core as topologic
 from topologicpy.Vertex import Vertex
 from topologicpy.Edge import Edge
 from topologicpy.Cluster import Cluster

--- a/tests/07CellComplex.py
+++ b/tests/07CellComplex.py
@@ -5,7 +5,7 @@ import sys
 sys.path.append("C:/Users/wassimj/Documents/GitHub")
 
 import topologicpy
-import topologic
+import topologic_core as topologic
 from topologicpy.Vertex import Vertex
 from topologicpy.Wire import Wire
 from topologicpy.Face import Face

--- a/tests/08Cluster.py
+++ b/tests/08Cluster.py
@@ -5,7 +5,7 @@ import sys
 sys.path.append("C:/Users/wassimj/Documents/GitHub")
 
 import topologicpy
-import topologic
+import topologic_core as topologic
 from topologicpy.Vertex import Vertex
 from topologicpy.Edge import Edge
 from topologicpy.Wire import Wire

--- a/tests/09Topology.py
+++ b/tests/09Topology.py
@@ -6,7 +6,7 @@ sys.path.append("C:/Users/wassimj/Documents/GitHub")
 
 from ast import FloorDiv
 import topologicpy
-import topologic
+import topologic_core as topologic
 from topologicpy.Vertex import Vertex
 from topologicpy.Edge import Edge
 from topologicpy.Cluster import Cluster

--- a/tests/10Dictionary.py
+++ b/tests/10Dictionary.py
@@ -5,7 +5,7 @@ import sys
 sys.path.append("C:/Users/wassimj/Documents/GitHub")
 
 import topologicpy
-import topologic
+import topologic_core as topologic
 from topologicpy.Vertex import Vertex
 from topologicpy.Edge import Edge
 from topologicpy.Cluster import Cluster

--- a/tests/11Grid.py
+++ b/tests/11Grid.py
@@ -5,7 +5,7 @@ import sys
 sys.path.append("C:/Users/wassimj/Documents/GitHub")
 
 import topologicpy
-import topologic
+import topologic_core as topologic
 from topologicpy.Vertex import Vertex
 from topologicpy.Edge import Edge
 from topologicpy.Cluster import Cluster

--- a/tests/12Matrix.py
+++ b/tests/12Matrix.py
@@ -5,7 +5,7 @@ import sys
 sys.path.append("C:/Users/wassimj/Documents/GitHub")
 
 import topologicpy
-import topologic
+import topologic_core as topologic
 from topologicpy.Vertex import Vertex
 from topologicpy.Edge import Edge
 from topologicpy.Cluster import Cluster

--- a/tests/13Graph.py
+++ b/tests/13Graph.py
@@ -5,7 +5,7 @@ import sys
 sys.path.append("C:/Users/wassimj/Documents/GitHub")
 
 import topologicpy
-import topologic
+import topologic_core as topologic
 from topologicpy.Vertex import Vertex
 from topologicpy.Edge import Edge
 from topologicpy.Cluster import Cluster

--- a/tests/14Vector.py
+++ b/tests/14Vector.py
@@ -6,7 +6,7 @@ sys.path.append("C:/Users/wassimj/Documents/GitHub")
 print("Start")
 print("20 Cases")
 import topologicpy
-import topologic
+import topologic_core as topologic
 from topologicpy.Vertex import Vertex
 from topologicpy.Edge import Edge
 from topologicpy.Cluster import Cluster


### PR DESCRIPTION
The purpose of this pull request is using `topologic-core` dependency in `topologicpy` project and getting rid of `./bin` directory. Please review/apply this patch once `topologic_core` is published on PyPI for all platforms.

@wassimj Since `topologicpy` repository doesn't contain `pyproject.toml`, you might need to add `topologic_core` to `dependencies` of your personal `pyproject.toml` file.