### PR TITLE
Refactor InternalVertex methods and improve Vertex intersection logic…

### DIFF
--- a/src/topologicpy/Face.py
+++ b/src/topologicpy/Face.py
@@ -1863,7 +1863,7 @@ class Face():
         return list(wires)
 
     @staticmethod
-    def InternalVertex(face, tolerance: float = 0.0001, silent: bool = False):
+    def InternalVertex_old(face, tolerance: float = 0.0001, silent: bool = False):
         """
         Creates a vertex guaranteed to be inside the input face.
 
@@ -1929,6 +1929,27 @@ class Face():
         vert = Topology.Vertices(face)[0]
         #v = topologic.FaceUtility.InternalVertex(face, tolerance) # Hook to Core
         return vert
+    
+    @staticmethod 
+    def InternalVertex(face, tolerance: float = 0.0001, silent: bool = False):
+        from topologicpy.Topology import Topology
+        from topologicpy.Vertex import Vertex
+        from topologicpy.Vector import Vector
+        from topologicpy.Edge import Edge
+        from topologicpy.Cluster import Cluster
+
+        if not Topology.IsInstance(face, "Face"):
+            return None
+        
+        v = Topology.Centroid(face)
+        
+        if Vertex.IsInternal(v, face):
+            return v
+        
+        #print("centroid is not internal")
+        V = Cluster.ByTopologies([Topology.Centroid(f) for f in Face.Triangulate(face)])
+        na = Vertex.NearestVertex(v, V)
+        return na
 
     @staticmethod
     def Invert(face, tolerance: float = 0.0001, silent: bool = False):

--- a/src/topologicpy/Topology.py
+++ b/src/topologicpy/Topology.py
@@ -9761,8 +9761,8 @@ class Topology():
                 faces = Topology.Faces(object)
                 for face in faces:
                     for selector in selectors:
-                        d = Vertex.Distance(selector, face)
-                        if d <= tolerance:
+                        s = Vertex.IsInternal(selector, face, tolerance)
+                        if s == True:
                             face = Topology.SetDictionary(face, Topology.Dictionary(selector), silent=True)
                             break
             if tranCells == True:


### PR DESCRIPTION
Refactor InternalVertex methods and improve Vertex IsInternal method.

1. A more robust and efficient method for finding a vertex on an irregular face via triangulation.
2. More efficient method to check if the vertex is in the face.
3. Switch transferring dictionaries to use the InInternal rather than Distance method between the selector Vertex and Face

Known caveat: Omits the effect tolerance for the match as is.
This could be solved for when explicitly declared tolerance is presented, but would probably introduce a slight decline in performance again. Better solution asks for a bit wider refactoring, that could bring further improvements also.

[Sample_notebook.zip](https://github.com/user-attachments/files/22793020/Sample_notebook.zip)
