### PR TITLE
Fix and optimise bvh queries

### DIFF
--- a/src/topologicpy/BVH.py
+++ b/src/topologicpy/BVH.py
@@ -342,12 +342,13 @@ class BVH:
         for topology in topologyList:
             if Topology.IsInstance(topology, "vertex"):
                 x,y,z = Vertex.Coordinates(topology, mantissa=mantissa)
-                points = [[x-tolerance, y-tolerance, z-tolerance], [x+tolerance, y+tolerance, z+tolerance]]
+                # points = [[x-tolerance, y-tolerance, z-tolerance], [x+tolerance, y+tolerance, z+tolerance]]
+                aabb_box = AABB(x-tolerance, y-tolerance, z-tolerance, x+tolerance, y+tolerance, z+tolerance)
             else:
                 points = [Vertex.Coordinates(v, mantissa=mantissa) for v in Topology.Vertices(topology)]
-            aabb_box = AABB.from_points(points, pad = tolerance)
+                aabb_box = AABB.from_points(points, pad = tolerance)
             return_topologies.extend([bvh.items[i] for i in BVH.QueryAABB(bvh, aabb_box)])
-        return return_topologies              
+        return return_topologies
 
     @staticmethod
     def Raycast(bvh, origin, direction: Tuple[float, float, float], mantissa: int = 6, silent: bool = False) -> List[int]:

--- a/src/topologicpy/Face.py
+++ b/src/topologicpy/Face.py
@@ -1933,7 +1933,12 @@ class Face():
             return centroid
 
         shell = Topology.Triangulate(face)
-        ib = Shell.InternalBoundaries(shell)
+        # ib = Shell.InternalEdges(shell)
+        # centroids = [Topology.Centroid(t) for t in ib]
+        faces = Topology.Faces(shell)
+        centroids = [Topology.Centroid(t) for t in faces]
+        cluster = Cluster.ByTopologies(centroids)
+        return Vertex.NearestVertex(centroid, cluster)
         cluster = Cluster.ByTopologies(ib)
         edges = Topology.Edges(cluster)
         bvh = BVH.ByTopologies(edges, tolerance=tolerance, silent=True)

--- a/src/topologicpy/Topology.py
+++ b/src/topologicpy/Topology.py
@@ -11392,7 +11392,7 @@ class Topology():
         return unflat_topology
     
     @staticmethod
-    def Vertices(topology, silent: bool = False):
+    def Vertices(topology, silent: bool = True):
         """
         Returns the vertices of the input topology.
 

--- a/src/topologicpy/Vertex.py
+++ b/src/topologicpy/Vertex.py
@@ -1293,7 +1293,13 @@ class Vertex():
         # --------------------------
         points = [Vertex.Coordinates(v) for v in Topology.Vertices(topology)]
         aabb = AABB.from_points(points, pad=tolerance)
+        if(Vertex.Coordinates(vertex) is None): 
+            if identify:
+                return (False, None)
+            return False
         if not aabb.contains_point(Vertex.Coordinates(vertex)):
+            if identify:
+                return (False, None)
             return False
 
         # --------------------------
@@ -1333,6 +1339,8 @@ class Vertex():
             edges = [] if faces or cells else collect_edges(topology)
             vertices = [] if edges or faces or cells else collect_vertices(topology)
         if not cells and not faces and not edges and not vertices:
+            if identify:
+                return (False, None)
             return False
 
         # --------------------------
@@ -1345,12 +1353,14 @@ class Vertex():
         primitives.extend(cells)
         bvh = BVH.ByTopologies(primitives, maxLeafSize=maxLeafSize, tolerance=tolerance, silent=True)
         try:
-            candidates = BVH.Clashes(bvh, vertex, tolernace=tolerance) or []
+            candidates = BVH.Clashes(bvh, vertex, tolerance=tolerance) or []
         except Exception:
             # Fallback if your BVH needs a non-degenerate query
             candidates = primitives
 
         if not candidates:
+            if identify:
+                return (False, None)
             return False
 
         # sort by types so that priority is given to lower dimensional types (e.g. vertices, then edges, then faces, then cells)


### PR DESCRIPTION
# A number of small bugfixes and speedups for the BVH utilisation for TransferDictionariesBySelectors

- Vertex.IsInternal bugs were causing fails for L-shaped faces, where centroid is not on the face. 
Hidden typo in a try block permanently failed and caused a fallback.

- FInding face internal vertex for irregular faces does not benefit from using BVH to run a single query.

- Creating a BVH for the primitives in Topology.TransferDictionariesBySelectors to use for all the selector queries is where it has most benefit. Otherwise Vertex.IsInternal on a cluster was matching each primitive on its own.

- The performance effects of triangulated face centres vs internal edge centres may be arguable.
Going for triangle centres feels more straightforward, but tested difference is actually negligible.

- AABB for a point clash can be created directly instead of going through a additional data structure.

Hope it makes sense.