### PR TITLE
Add `torch_geometric` as dependency (required in PyG.py)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "lark",
     "specklepy",
     "webcolors",
+    "torch_geometric",
     "topologic_core>=7.0.1",
 ]
 


### PR DESCRIPTION
This shall solve the issue of the Sphinx generator failing on `PyG.py`.