### PR TITLE
Fix face bywire bug

### DIFF
--- a/src/topologicpy/Face.py
+++ b/src/topologicpy/Face.py
@@ -1144,7 +1144,7 @@ class Face():
         # Make sure all internal wires are actually inside the external wire.
         ibList = []
         for ib in internalBoundaries:
-            if not Topology.IsInstance(ib, "Wire") and Wire.IsClosed(ib):
+            if not (Topology.IsInstance(ib, "Wire") and Wire.IsClosed(ib)):
                 if not silent:
                     print("Face.ByWires - Warning: One of the internal wires is not a valid closed wire. Ignoring.")
                     curframe = inspect.currentframe()

--- a/src/topologicpy/Face.py
+++ b/src/topologicpy/Face.py
@@ -1143,13 +1143,18 @@ class Face():
         eb_area = Face.Area(eb_face)
         # Make sure all internal wires are actually inside the external wire.
         ibList = []
+        ibImprint = []
         for ib in internalBoundaries:
-            if not (Topology.IsInstance(ib, "Wire") and Wire.IsClosed(ib)):
+            if not (Topology.IsInstance(ib, "Wire"):
                 if not silent:
-                    print("Face.ByWires - Warning: One of the internal wires is not a valid closed wire. Ignoring.")
+                    print("Face.ByWires - Warning: One of the internal wires is not a valid wire. Ignoring.")
                     curframe = inspect.currentframe()
                     calframe = inspect.getouterframes(curframe, 2)
                     print('caller name:', calframe[1][3])
+                continue
+            # Wire is not closed but lets try to imprint it
+            if not Wire.IsClosed(ib):  
+                ibImprint.append(ib)    
                 continue
             ib_face = Face.ByWire(ib)
             ib_area = Face.Area(ib_face)
@@ -1172,6 +1177,8 @@ class Face():
         face = None
         try:
             face = Core.Face.ByExternalInternalBoundaries(externalBoundary, ibList, tolerance)
+            if ibImprint:
+                face = Topology.Imprint(face, Topology.MergeAll(ibImprint), tolerance=tolerance)
         except:
             if not silent:
                 print("Face.ByWires - Error: The operation failed. Returning None.")


### PR DESCRIPTION
The first commit is a typo fix for a logical bug. Input validation lets the invalid wire pass for the IsClosed and valid wire is never tested for IsClosed, it produces a crash. What was probably intended is that it should pass both tests to not to fall into this invalidation statement.

The second commit on the other hand lets the non-closed wire pass to be collected as a wire to be later imprinted on the face. It is a case that perhaps needs addressing although maybe there is another interpretation. I needed in for a JSON serialised topology to come trough. as stored.