### PR TITLE
Optimize internal vertex detection and centroid calculation in Face class

### DIFF
--- a/src/topologicpy/Face.py
+++ b/src/topologicpy/Face.py
@@ -2117,7 +2117,8 @@ class Face():
             if v is None:
                 return False
             try:
-                return Vertex.IsInternal(v, face, tolerance=tolerance)
+                if Topology.Intersect(v, face, tolerance=tolerance):
+                    return not Topology.Intersect(v, Cluster.ByTopologies(Topology.Edges(face)), tolerance=tolerance)
             except TypeError:
                 return Vertex.IsInternal(v, face)
 
@@ -2186,7 +2187,7 @@ class Face():
 
         # 1. Try the face centroid first.
         try:
-            centroid = Topology.Centroid(face)
+            centroid = Topology.VerticesCentroid(face, mantissa=17)
             if _is_internal(centroid):
                 return centroid
         except Exception:
@@ -2201,24 +2202,26 @@ class Face():
 
             for tri_face in tri_faces:
                 try:
-                    tri_centroid = Topology.Centroid(tri_face)
-                    if _is_internal(tri_centroid):
-                        candidates.append(tri_centroid)
+                    tri_centroid = Topology.VerticesCentroid(tri_face, mantissa=17)
+                    # if _is_internal(tri_centroid): no need to check, a triangle centroid is intrenal unless the triangle is degenerate
+                    candidates.append(tri_centroid)
                 except Exception:
                     continue
         except Exception:
             tri_faces = []
 
+
         if candidates:
+            boundary = Cluster.ByTopologies(Topology.Edges(face))
+            # Creating a list of distance, candidate tuples for optimal sorting
+            distanceCandidates = [(_distance_to_boundary(c, boundary), c) for c in candidates]
             try:
-                boundary = Cluster.ByTopologies(Topology.Edges(face))
-                candidates.sort(
-                    key=lambda v: _distance_to_boundary(v, boundary),
+                distanceCandidates.sort(
                     reverse=True
                 )
             except Exception:
                 pass
-            return candidates[0]
+            return distanceCandidates[0][1] # returning the candidate from the first tuple
 
         # 3. Fallback: construct a robust local coordinate system.
         try:

--- a/src/topologicpy/Topology.py
+++ b/src/topologicpy/Topology.py
@@ -1469,11 +1469,11 @@ class Topology():
 
         if not Topology.IsInstance(topologyA, "topology"):
             if not silent:
-                print("Topology.Intersect - Error: The topologyA input parameter is not a valid Topology. Reteruning None.")
+                print("Topology.Intersect - Error: The topologyA input parameter is not a valid Topology. Returning None.")
             return None
         if not Topology.IsInstance(topologyB, "topology"):
             if not silent:
-                print("Topology.Intersect - Error: The topologyA input parameter is not a valid Topology. Reteruning None.")
+                print("Topology.Intersect - Error: The topologyB input parameter is not a valid Topology. Returning None.")
             return None
         
         from topologicpy.Vertex import Vertex


### PR DESCRIPTION
Here is a more optimised variant of the internal vertex method.
Opting for faster low level boolean methods first.
Opting for simpler Topology.VerticesCentroid method as the Internal Vertex does not need to be mathematical centroid.
Removing _is_internal checks for triangulated faces. Only way the centroid would not be in a triangle is if it has zero area and is degenerate. Most likely this is avoided by other means and later any proper triangle would be preferred in the furthest edge sorting anyway.

Including a test results for some toplogicpy versions and the test script. The times may range 10-20% each run and the first is usually slower. The test pattern contains 72 faces and 48 are L-shaped where the centroid falls outside of the face.
<img width="414" height="264" alt="v0-8-99" src="https://github.com/user-attachments/assets/76e5c585-e74f-4aa5-bea8-e90091816a56" />
<img width="414" height="264" alt="v0-9-26" src="https://github.com/user-attachments/assets/0ed566e1-118e-47e9-9614-fbd58976a04f" />
<img width="414" height="264" alt="v0-9-28" src="https://github.com/user-attachments/assets/7932b18f-ea9c-475f-a164-86fc89a59fce" />
<img width="414" height="264" alt="v0-9-31_original" src="https://github.com/user-attachments/assets/1116657f-b30d-4abf-b629-a2ed63902fde" />

The optimised version in the PR.
<img width="426" height="253" alt="v0-9-31x_optimised" src="https://github.com/user-attachments/assets/2a4c63d0-af9d-4c96-ae10-6bed87237a55" />

[MeanderGrid_SpatialLayout_Half.json](https://github.com/user-attachments/files/27907288/MeanderGrid_SpatialLayout_Half.json)
[TestFaceSelectors.ipynb](https://github.com/user-attachments/files/27907290/TestFaceSelectors.ipynb)
