### PR TITLE
Guard Vertex.Project/Distance when Face.PlaneEquation returns None

### DIFF
--- a/src/topologicpy/Vertex.py
+++ b/src/topologicpy/Vertex.py
@@ -791,7 +791,7 @@ class Vertex():
         
         def distance_to_face(vertex, face, includeCentroid):
             v_proj = Vertex.Project(vertex, face, mantissa=mantissa)
-            if not Vertex.IsInternal(v_proj, face):
+            if v_proj is None or not Vertex.IsInternal(v_proj, face):
                 vertices = Topology.Vertices(face)
                 distances = [distance_to_vertex(vertex, v) for v in vertices]
                 edges = Topology.Edges(face)
@@ -800,6 +800,14 @@ class Vertex():
                     distances.append(distance_to_vertex(vertex, Topology.Centroid(face)))
                 return min(distances)
             dic = Face.PlaneEquation(face)
+            if dic is None:
+                vertices = Topology.Vertices(face)
+                distances = [distance_to_vertex(vertex, v) for v in vertices]
+                edges = Topology.Edges(face)
+                distances += [distance_to_edge(vertex, e) for e in edges]
+                if includeCentroid:
+                    distances.append(distance_to_vertex(vertex, Topology.Centroid(face)))
+                return min(distances)
             a = dic["a"]
             b = dic["b"]
             c = dic["c"]
@@ -3023,6 +3031,8 @@ class Vertex():
         if not Topology.IsInstance(face, "Face"):
             return None
         eq = Face.PlaneEquation(face, mantissa= mantissa)
+        if eq is None:
+            return None
         if direction == None or direction == []:
             direction = Face.Normal(face)
         pt = project_point_onto_plane(Vertex.Coordinates(vertex), [eq["a"], eq["b"], eq["c"], eq["d"]], direction)


### PR DESCRIPTION
## Summary

`Face.PlaneEquation(face)` can return `None` for degenerate faces (for example faces with fewer than 3 vertices after geometry cleanup/fusing).
`Vertex.Project` and `Vertex.Distance` currently assume a dict is always returned and may crash with:

`'NoneType' object is not subscriptable`

This PR adds small defensive guards so those cases return/fallback safely instead of raising.

## Changes

In `src/topologicpy/Vertex.py`:

- `Vertex.Distance` (`distance_to_face`):
  - Treat `v_proj is None` the same as non-internal projection and use boundary distance fallback.
  - If `Face.PlaneEquation(face)` returns `None`, use the existing boundary-distance fallback path instead of subscripting `dic["a"]...`.

- `Vertex.Project`:
  - If `Face.PlaneEquation(face)` returns `None`, return `None` early.

## Why

Degenerate faces are expected in some real-world IFC-derived workflows.
This keeps behavior robust and prevents hard failure in distance/projection calls.

## Validation

Validated locally on `topologicpy==0.9.43` with a real IFC workload:

- Before patch: repeated `NoneType` crash path (`TopologicPy distance call failed ... 'NoneType' object is not subscriptable`) — 10/10 sample elements hit this fallback.
- After patch: 0/10 crashes for the same sample and inputs.
- Match outcome stayed stable (same matched/unmatched counts).

## Scope

- Minimal change (null-guards only)
- No API changes
- No behavior changes for valid non-degenerate faces

Made with [Cursor](https://cursor.com)